### PR TITLE
admin: expose eds_service_name to admin response of clusters

### DIFF
--- a/api/envoy/admin/v3/clusters.proto
+++ b/api/envoy/admin/v3/clusters.proto
@@ -84,6 +84,9 @@ message ClusterStatus {
 
   // Observability name of the cluster.
   string observability_name = 7;
+
+  // eds_service_name from EDS config of the cluster.
+  string eds_service_name = 8;
 }
 
 // Current state of a particular host.

--- a/source/server/admin/clusters_handler.cc
+++ b/source/server/admin/clusters_handler.cc
@@ -115,6 +115,10 @@ void ClustersHandler::writeClustersAsJson(Buffer::Instance& response) {
     envoy::admin::v3::ClusterStatus& cluster_status = *clusters.add_cluster_statuses();
     cluster_status.set_name(cluster_info->name());
     cluster_status.set_observability_name(cluster_info->observabilityName());
+    auto eds_service_name = cluster_info->edsServiceName();
+    if (eds_service_name.has_value()) {
+      cluster_status.set_eds_service_name(*eds_service_name);
+    }
 
     addCircuitBreakerSettingsAsJson(
         envoy::config::core::v3::RoutingPriority::DEFAULT,


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Expose eds_service_name as an optional string to the ClusterStatus proto, and adding populating logic.
Additional Description: The data is already available in the ClusterInfo class. ([link](https://github.com/envoyproxy/envoy/blob/main/source/common/upstream/upstream_impl.h#L770))
Risk Level: Low
Testing: TBD
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue] TBD
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
